### PR TITLE
Fix compilation error on visionOS

### DIFF
--- a/Sources/InterfaceOrientation/InterfaceOrientationCoordinator.swift
+++ b/Sources/InterfaceOrientation/InterfaceOrientationCoordinator.swift
@@ -74,12 +74,13 @@ public class InterfaceOrientationCoordinator: ObservableObject {
         self.defaultOrientations = defaultOrientations
         self.allowOverridingDefaultOrientations = allowOverridingDefaultOrientations
 
+        #if !os(visionOS)
         NotificationCenter.default.publisher(for: UIDevice.orientationDidChangeNotification)
             .sink { _ in
                 self.resolveOrientations()
             }
             .store(in: &cancellables)
-
+        #endif
         resolveOrientations()
     }
 


### PR DESCRIPTION
Currently is not possible to compile for visionOS, just opted out orientationDidChangeNotification for it.